### PR TITLE
Configure Dev Space extensions, Python environment, and fix CMake error.

### DIFF
--- a/containers/devspace/Dockerfile
+++ b/containers/devspace/Dockerfile
@@ -4,6 +4,7 @@ FROM quay.io/centos/centos:stream9
 COPY --from=uv /uv /uvx /bin/
 RUN dnf install -y \
       epel-release && \
+    dnf copr enable chmouel/tektoncd-cli && \
     dnf install -y \
       compat-openssl11 \
       libbrotli \
@@ -29,6 +30,8 @@ RUN dnf install -y \
       boost-atomic \
       boost-filesystem \
       boost-regex \
+      clang-tools \
+      tektoncd-cli \
       && dnf clean all \
       && rm -rf /var/cache/dnf
 

--- a/containers/devspace/Dockerfile
+++ b/containers/devspace/Dockerfile
@@ -4,7 +4,6 @@ FROM quay.io/centos/centos:stream9
 COPY --from=uv /uv /uvx /bin/
 RUN dnf install -y \
       epel-release && \
-    dnf copr enable chmouel/tektoncd-cli && \
     dnf install -y \
       compat-openssl11 \
       libbrotli \
@@ -30,8 +29,7 @@ RUN dnf install -y \
       boost-atomic \
       boost-filesystem \
       boost-regex \
-      clang-tools \
-      tektoncd-cli \
+      clang-tools-extra \
       && dnf clean all \
       && rm -rf /var/cache/dnf
 

--- a/templates/autosd-app-template/skeleton/.gitignore
+++ b/templates/autosd-app-template/skeleton/.gitignore
@@ -1,4 +1,5 @@
 build/
+.cache/
 _build
 .secure_files
 *.tar.gz

--- a/templates/autosd-app-template/skeleton/.gitignore
+++ b/templates/autosd-app-template/skeleton/.gitignore
@@ -1,3 +1,4 @@
+build/
 _build
 .secure_files
 *.tar.gz

--- a/templates/autosd-app-template/skeleton/.vscode/cmake-kits.json
+++ b/templates/autosd-app-template/skeleton/.vscode/cmake-kits.json
@@ -1,0 +1,10 @@
+[
+    {
+      "name": "GCC 11.5.0 x86_64-redhat-linux",
+      "compilers": {
+        "C": "/usr/bin/gcc",
+        "CXX": "/usr/bin/g++"
+      },
+      "isTrusted": true
+    }
+  ]

--- a/templates/autosd-app-template/skeleton/.vscode/extensions.json
+++ b/templates/autosd-app-template/skeleton/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
-        "kylinideteam.kylin-cpp-pack",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cmake-tools",
         "ms-python.python",
         "ms-python.debugpy",
         "redhat.vscode-tekton-pipelines",

--- a/templates/autosd-app-template/skeleton/.vscode/extensions.json
+++ b/templates/autosd-app-template/skeleton/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "ms-python.python",
         "ms-python.debugpy",
         "redhat.vscode-tekton-pipelines",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "pkief.material-icon-theme"
     ]
 }

--- a/templates/autosd-app-template/skeleton/.vscode/extensions.json
+++ b/templates/autosd-app-template/skeleton/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "kylinideteam.kylin-cpp-pack",
+        "ms-python.python",
+        "ms-python.debugpy",
+        "redhat.vscode-tekton-pipelines",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/templates/autosd-app-template/skeleton/.vscode/settings.json
+++ b/templates/autosd-app-template/skeleton/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cmake.sourceDirectory": "${workspaceFolder}/src",
     "cmake.buildDirectory": "${workspaceFolder}/build",
+    "cmake.showOptionsMovedNotification": false,
     "cmake.options.statusBarVisibility": "hidden",
     "python.defaultInterpreterPath": "/jumpstarter/bin/python"
 }

--- a/templates/autosd-app-template/skeleton/.vscode/settings.json
+++ b/templates/autosd-app-template/skeleton/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
-    "cmake.sourceDirectory": "/projects/autosd-app-demo-pic/src",
-    "python.defaultInterpreterPath": "/jumpstarter/bin/python",
+    "cmake.sourceDirectory": "${workspaceFolder}/src",
+    "cmake.buildDirectory": "${workspaceFolder}/build",
+    "cmake.options.statusBarVisibility": "hidden",
+    "python.defaultInterpreterPath": "/jumpstarter/bin/python"
 }

--- a/templates/autosd-app-template/skeleton/.vscode/settings.json
+++ b/templates/autosd-app-template/skeleton/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "cmake.sourceDirectory": "/projects/autosd-app-demo-pic/src",
+    "python.defaultInterpreterPath": "/jumpstarter/bin/python",
+}

--- a/templates/autosd-app-template/skeleton/.vscode/settings.json
+++ b/templates/autosd-app-template/skeleton/.vscode/settings.json
@@ -3,5 +3,7 @@
     "cmake.buildDirectory": "${workspaceFolder}/build",
     "cmake.showOptionsMovedNotification": false,
     "cmake.options.statusBarVisibility": "hidden",
-    "python.defaultInterpreterPath": "/jumpstarter/bin/python"
+    "cmake.enableAutomaticKitScan": true,
+    "editor.inlayHints.enabled": "off",
+    "python.defaultInterpreterPath": "/jumpstarter/bin/python",
 }

--- a/templates/autosd-app-template/skeleton/src/CMakeLists.txt
+++ b/templates/autosd-app-template/skeleton/src/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(auto-apps)
-
 cmake_minimum_required (VERSION 2.10)
+
+project(auto-apps)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Adds Dev Space OpenVSX Extensions for:
- `llvm-vs-code-extensions.vscode-clangd`
- `ms-vscode.cmake-tools`
- `ms-python.python`
- `ms-python.debugpy`
- `redhat.vscode-tekton-pipelines`
- `redhat.vscode-yaml`
- `pkief.material-icon-theme`

Without extensions added:
- **CPU** 8-100m (peak when loading)
- **Memory** 0.4-0.6 GB (peak when all files open)

With extensions added:
- **CPU** 8-1000m (peak when all files open, indexing C++/Python)
- **Memory** 0.75-1.2 GB (peak when all files open, indexing C++/Python)