### PR TITLE
Switch to classic menu bar in settings.json

### DIFF
--- a/templates/autosd-app-template/skeleton/.vscode/settings.json
+++ b/templates/autosd-app-template/skeleton/.vscode/settings.json
@@ -8,5 +8,6 @@
     "python.defaultInterpreterPath": "/jumpstarter/bin/python",
     "chat.commandCenter.enabled": false,
     "security.workspace.trust.enabled": false,
-    "git.enableSmartCommit": true
+    "git.enableSmartCommit": true,
+    "window.menuBarVisibility": "classic"
 }


### PR DESCRIPTION
This will use the classic menu bar instead of the nested one for simpler instructions in the lab.